### PR TITLE
Adding minimum esphome version to yaml's

### DIFF
--- a/econet_heatpump_water_heater.yaml
+++ b/econet_heatpump_water_heater.yaml
@@ -9,6 +9,7 @@ esphome:
   name: ${name}
   friendly_name: ${friendly_name}
   comment: ${device_description}
+  min_version: "2023.2.0"
 
 preferences:
   flash_write_interval: "24h"

--- a/econet_hvac.yaml
+++ b/econet_hvac.yaml
@@ -9,6 +9,7 @@ esphome:
   name: ${name}
   friendly_name: ${friendly_name}
   comment: ${device_description}
+  min_version: "2023.2.0"
 
 preferences:
   flash_write_interval: "24h"

--- a/econet_tankless_water_heater.yaml
+++ b/econet_tankless_water_heater.yaml
@@ -9,6 +9,7 @@ esphome:
   name: ${name}
   friendly_name: ${friendly_name}
   comment: ${device_description}
+  min_version: "2023.2.0"
 
 preferences:
   flash_write_interval: "24h"


### PR DESCRIPTION
I found that because of the `friendly_name` property, which improves entity naming in Home Assistant, you can't build on pre-2023 releases. Seems like a good practice to set a reasonably modern baseline anyway.