### PR TITLE
Adding ALRMALRT fetch and disabled sensor.

### DIFF
--- a/components/econet/econet.cpp
+++ b/components/econet/econet.cpp
@@ -183,6 +183,7 @@ void Econet::make_request() {
       str_ids.push_back("EVAPTEMP");
       str_ids.push_back("SUCTIONT");
       str_ids.push_back("DISCTEMP");
+      str_ids.push_back("ALRMALRT");
     } else if (model_type_ == MODEL_TYPE_HVAC && !hvac_wifi_module_connected_) {
       str_ids.push_back("DHUMSETP");
       str_ids.push_back("DHUMENAB");

--- a/econet_heatpump_water_heater.yaml
+++ b/econet_heatpump_water_heater.yaml
@@ -127,6 +127,14 @@ sensor:
     device_class: "temperature"
     state_class: "measurement"
     entity_category: "diagnostic"
+  - platform: econet
+    name: "Active Alerts"
+    sensor_datapoint: ALRMALRT
+    accuracy_decimals: 0
+    icon: "mdi:water-boiler-alert"
+    state_class: "measurement"
+    entity_category: "diagnostic"
+    disabled_by_default: "true"
   - platform: wifi_signal
     name: "WiFi Signal Strength"
     update_interval: 30s

--- a/econet_heatpump_water_heater.yaml
+++ b/econet_heatpump_water_heater.yaml
@@ -127,14 +127,6 @@ sensor:
     device_class: "temperature"
     state_class: "measurement"
     entity_category: "diagnostic"
-  - platform: econet
-    name: "Active Alerts"
-    sensor_datapoint: ALRMALRT
-    accuracy_decimals: 0
-    icon: "mdi:water-boiler-alert"
-    state_class: "measurement"
-    entity_category: "diagnostic"
-    disabled_by_default: "true"
   - platform: wifi_signal
     name: "WiFi Signal Strength"
     update_interval: 30s


### PR DESCRIPTION
As is being discussed in #water-heaters in Discord, we'd like to get Alert tracking working. So far, ALRMALRT is the only thing we've seen work. I'd like to get this into the codebase so I can notify on it in HASS and hopefully catch the next time an alert occurs for testing.

Sensor is added but disabled by default since we don't fully understand it yet.